### PR TITLE
Fix: Never save the redis databases on disk

### DIFF
--- a/redis-server/redis-openvas.conf
+++ b/redis-server/redis-openvas.conf
@@ -197,7 +197,7 @@ databases 1025
 #   points by adding a save directive with a single empty string argument
 #   like in the following example:
 #
-#   save ""
+save ""
 
 # save 900 1
 # save 300 10


### PR DESCRIPTION
## What

Never save the redis databases on disk

## Why

Saving the redis databases to disk was never intended because we use redis as a cache only. With Debian Bookworm this seems to be even more broken then before because redis can't write to the default storage paths.



## References

#7 

