### PR TITLE
Change: upgrade Redis to 8.2.2 and enable Dependabot Docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
       actions:
         patterns:
           - "*"
+  - package-ecosystem: "docker"
+    directory: "/redis-server"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/redis-server/Dockerfile
+++ b/redis-server/Dockerfile
@@ -1,16 +1,14 @@
-FROM debian:stable-slim
+FROM redis:8.2.2
 
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get -y update && apt-get -y upgrade && \
-    apt-get --no-install-recommends --no-install-suggests -y install redis
-
+# Copy in the custom Redis configuration
 COPY redis-openvas.conf /etc/redis/redis.conf
 
+# Create gvm group and adjust permissions for Redis runtime
 RUN addgroup --system --gid 1001 gvm && \
     usermod -a -G gvm redis && \
     mkdir /run/redis && chown redis:gvm /run/redis
 
 USER redis
 
+# Ensure socket is cleaned up before starting
 CMD rm -f /run/redis/redis.sock && redis-server /etc/redis/redis.conf


### PR DESCRIPTION
## What

Upgrade Redis to 8.2.2 (fix CVE‑2025‑49844) and add Dependabot for Docker updates.

## Why

Keeps images secure and ensures future base image updates are tracked automatically.

## References

[DOS-483](https://jira.greenbone.net/browse/DOS-483)

## Checklist


- [ ] Tests


