### PR TITLE
Change: Push all images to greenbone harbor registry

### DIFF
--- a/.github/workflows/container-doxgen.yml
+++ b/.github/workflows/container-doxgen.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   doxygen-images:
     name: Build and upload doxygen container images
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-generic
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/container-gpg-data.yml
+++ b/.github/workflows/container-gpg-data.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   gpg-data-images:
     name: Build and upload container images with gpg data
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-generic
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/container-mqtt-broker.yml
+++ b/.github/workflows/container-mqtt-broker.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   mqtt-broker-images:
     name: Build and upload container images for mqtt broker
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-generic
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/container-redis-server.yml
+++ b/.github/workflows/container-redis-server.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   redis-images:
     name: Build and upload redis container images
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-generic
 
     steps:
       - name: Checkout repository
@@ -81,7 +81,7 @@ jobs:
 
   redis-images-ghcr:
     name: Build and upload redis container images to ghcr.io
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-generic
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## What
Push all of the remaining images to greenbone harbor registry too.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
All of the openvas-ai images should be available on the greenbone harbor registry.
<!-- Describe why are these changes necessary? -->

## References
https://jira.greenbone.net/browse/DEVOPS-1822
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Test the workflows after they have been merged(they won't push anything when they aren't run from main)


