### PR TITLE
Fix: Change latest tag to server-cuda for llama.cpp

### DIFF
--- a/.github/workflows/container-llama-cpp.yml
+++ b/.github/workflows/container-llama-cpp.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Push image to GHCR
         run: |
           docker buildx imagetools create \
-            --tag ghcr.io/greenbone/llama.cpp:latest \
-            ghcr.io/ggml-org/llama.cpp:latest
+            --tag ghcr.io/greenbone/llama.cpp:server-cuda \
+            ghcr.io/ggml-org/llama.cpp:server-cuda
 
       - name: Push image to Harbor
         run: |
           docker buildx imagetools create \
-            --tag ${{ vars.GREENBONE_REGISTRY }}/openvas-ai/llama.cpp:latest \
-            ghcr.io/ggml-org/llama.cpp:latest
+            --tag ${{ vars.GREENBONE_REGISTRY }}/openvas-ai/llama.cpp:server-cuda \
+            ghcr.io/ggml-org/llama.cpp:server-cuda


### PR DESCRIPTION
## What
llama.ccp image doesn't have a latest tag and needs a explicit tag to chose a backend.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
llama.ccp image doesn't have a latest tag and needs a explicit tag to chose a backend.
<!-- Describe why are these changes necessary? -->

## References
https://jira.greenbone.net/browse/DEVOPS-1821
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] push llama.cpp workflow runs successfully


