### PR TITLE
Allow CORS preflight requests for gsad

### DIFF
--- a/gvm-config/templates/default.conf.template
+++ b/gvm-config/templates/default.conf.template
@@ -37,6 +37,15 @@ server {
   ssl_certificate_key {{nginx_server_key}};
 
   location ~ ^/(gmp|system_report|logout) {
+    # Handle preflight requests
+    if ($request_method = OPTIONS) {
+          add_header Access-Control-Allow-Origin "{{nginx_access_control_allow_origin_header}}" always;
+          add_header Access-Control-Allow-Credentials "true" always;
+          add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" always;
+          add_header Access-Control-Allow-Headers "Content-Type, Authorization" always;
+          add_header Content-Length 0 always;
+          return 204;
+    }
     proxy_pass http://gsad;
     proxy_hide_header Access-Control-Allow-Origin;
     proxy_hide_header Content-Security-Policy;


### PR DESCRIPTION


## What

Allow CORS preflight requests for gsad

## Why

When adding an Authorization header browser's will create a CORS preflight (OPTIONS) request for gsad too. Therefore we have to allow it too.